### PR TITLE
add more options and delete deprecated vivid option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-# atom-build-clickable
+# atom-clickable-plugin
 
-Clickable add-on for Atom editor.
+This *atom-clickable-plugin* does provide some common clickable tools needed to build and run click packages for Ubuntu Touch from within Atom editor.
+
+##Credits
+*This is a fork of the (now unmaintained) original atom-build-clickable plugin for Atom by @sverzegnassi. Many thanks to you for this great work!*
 
 ## Prerequisites
 
 This package requires [clickable](https://github.com/bhdouglass/clickable) to be installed and available on your system.
- 
+
 ## License
 
 This project is licensed under the terms of the MIT license. See `LICENSE` for details.
-

--- a/lib/clickable.js
+++ b/lib/clickable.js
@@ -129,7 +129,7 @@ export function provideBuilder() {
       {
         name: 'Clickable: Build --NVIDIA and run [desktop]',
         exec: 'clickable',
-        args: [ 'desktop --nvidia' ],
+        args: [ 'desktop','--nvidia' ],
         sh: false,
         functionMatch: function (terminal_output) {
           return errorHelper.checkBuildError(terminal_output)

--- a/lib/clickable.js
+++ b/lib/clickable.js
@@ -152,6 +152,15 @@ export function provideBuilder() {
         functionMatch: function (terminal_output) {
           return errorHelper.checkBuildError(terminal_output)
         }
+      },
+      {
+        name: 'Clickable: Update [docker container]',
+        exec: 'clickable',
+        args: [ 'update' ],
+        sh: false,
+        functionMatch: function (terminal_output) {
+          return errorHelper.checkBuildError(terminal_output)
+        }
       }];
     }
   }

--- a/lib/clickable.js
+++ b/lib/clickable.js
@@ -118,9 +118,36 @@ export function provideBuilder() {
         }
       },
       {
-        name: 'Clickable: Build and run [phone (vivid 15.04)]',
+        name: 'Clickable: Build --dirty and run [phone]',
         exec: 'clickable',
-        args: [ '--vivid' ],
+        args: [ '--dirty' ],
+        sh: false,
+        functionMatch: function (terminal_output) {
+          return errorHelper.checkBuildError(terminal_output)
+        }
+      },
+      {
+        name: 'Clickable: Build --NVIDIA and run [desktop]',
+        exec: 'clickable',
+        args: [ 'desktop --nvidia' ],
+        sh: false,
+        functionMatch: function (terminal_output) {
+          return errorHelper.checkBuildError(terminal_output)
+        }
+      },
+      {
+        name: 'Clickable: Clean-build',
+        exec: 'clickable',
+        args: [ 'clean-build' ],
+        sh: false,
+        functionMatch: function (terminal_output) {
+          return errorHelper.checkBuildError(terminal_output)
+        }
+      },
+      {
+        name: 'Clickable: Review',
+        exec: 'clickable',
+        args: [ 'review' ],
         sh: false,
         functionMatch: function (terminal_output) {
           return errorHelper.checkBuildError(terminal_output)

--- a/lib/clickable.js
+++ b/lib/clickable.js
@@ -98,11 +98,21 @@ export function provideBuilder() {
 
     settings() {
       const errorHelper = require('./check_errors');
+      var customParams = atom.config.get(meta.name + '.customClickable');
 
       return [{
         name: 'Clickable: Build and run [phone]',
         exec: 'clickable',
         args: [ ],
+        sh: false,
+        functionMatch: function (terminal_output) {
+          return errorHelper.checkBuildError(terminal_output)
+        }
+      },
+      {
+        name: 'Clickable: custom [' + customParams + ']',
+        exec: 'clickable',
+        args: customParams.split(','),
         sh: false,
         functionMatch: function (terminal_output) {
           return errorHelper.checkBuildError(terminal_output)
@@ -136,16 +146,7 @@ export function provideBuilder() {
         }
       },
       {
-        name: 'Clickable: Clean-build',
-        exec: 'clickable',
-        args: [ 'clean-build' ],
-        sh: false,
-        functionMatch: function (terminal_output) {
-          return errorHelper.checkBuildError(terminal_output)
-        }
-      },
-      {
-        name: 'Clickable: Review',
+        name: 'Clickable: Review [click package]',
         exec: 'clickable',
         args: [ 'review' ],
         sh: false,

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,18 +8,25 @@ export default {
     default: 'x-terminal-emulator',
     order: 0
   },
+  customClickable: {
+    title: 'Custom clickable parameters',
+    description: 'Set parameters for custom clickable command [comma separated]',
+    type: 'string',
+    default: 'desktop, --nvidia',
+    order: 1
+  },
   manageDependencies: {
     title: 'Manage Dependencies',
     description: 'When enabled, third-party dependencies will be installed automatically',
     type: 'boolean',
     default: true,
-    order: 1
+    order: 2
   },
   alwaysEligible: {
     title: 'Always Eligible',
     description: 'The build provider will be available in your project, even when not eligible',
     type: 'boolean',
     default: false,
-    order: 2
+    order: 3
   }
 };


### PR DESCRIPTION
This PR will:
- remove the deprecated vivid option
- add new options for 
  * clickable --dirty
  * clickable desktop --nvidia (fix #5 )
  * clickable review
  * clickable update
  * clickable *custom command* (parameters to be set in settings)